### PR TITLE
Fix power control examples

### DIFF
--- a/Examples/Peripheral_Power_Control/Peripheral_Power_Control.ino
+++ b/Examples/Peripheral_Power_Control/Peripheral_Power_Control.ino
@@ -33,22 +33,22 @@ void loop() {
   delay(2000);
 }
 
-//Qwiic connector power is controlled from P-channel MOSFET so logic is reversed
+//Qwiic connector power is controlled from an LDO voltage regulator
 void qwiicPowerOn()
-{
-  digitalWrite(qwiicPowerControl, LOW);
-}
-void qwiicPowerOff()
 {
   digitalWrite(qwiicPowerControl, HIGH);
 }
+void qwiicPowerOff()
+{
+  digitalWrite(qwiicPowerControl, LOW);
+}
 
-//3V3 peripheral power is controlled from P-channel MOSFET so logic is reversed
+//3V3 peripheral power is controlled from an LDO voltage regulator
 void peripheralPowerOn()
 {
-  digitalWrite(peripheralPowerControl, LOW);
+  digitalWrite(peripheralPowerControl, HIGH);
 }
 void peripheralPowerOff()
 {
-  digitalWrite(peripheralPowerControl, HIGH);
+  digitalWrite(peripheralPowerControl, LOW);
 }

--- a/Examples/Power_Control/Power_Control.ino
+++ b/Examples/Power_Control/Power_Control.ino
@@ -35,22 +35,22 @@ void loop() {
   delay(2000);
 }
 
-//Qwiic connector power is controlled from P-channel MOSFET so logic is reversed
+//Qwiic connector power is controlled from an LDO voltage regulator
 void qwiicPowerOn()
-{
-  digitalWrite(qwiicPowerControl, LOW);
-}
-void qwiicPowerOff()
 {
   digitalWrite(qwiicPowerControl, HIGH);
 }
+void qwiicPowerOff()
+{
+  digitalWrite(qwiicPowerControl, LOW);
+}
 
-//3V3 peripheral power is controlled from P-channel MOSFET so logic is reversed
+//3V3 peripheral power is controlled from an LDO voltage regulator
 void peripheralPowerOn()
 {
-  digitalWrite(peripheralPowerControl, LOW);
+  digitalWrite(peripheralPowerControl, HIGH);
 }
 void peripheralPowerOff()
 {
-  digitalWrite(peripheralPowerControl, HIGH);
+  digitalWrite(peripheralPowerControl, LOW);
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SparkFun MicroMod Data Logging Carrier Board
 ========================================
 
-![SparkFun MicroMod Data Logging Carrier Board](https://cdn.sparkfun.com/assets/parts/1/5/7/5/0/16829-SparkFun_MicroMod_Data_Logging_Carrier_Board-01.jpg)
+![SparkFun MicroMod Data Logging Carrier Board](https://cdn.sparkfun.com/assets/parts/1/5/7/5/0/16829-SparkFun_MicroMod_Data_Logging_Carrier_Board-01A.jpg)
 
 [SparkFun MicroMod Data Logging Carrier Board (DEV-16829)](https://www.sparkfun.com/products/16829)
 


### PR DESCRIPTION
A minor update to correct the power control examples to reflect the change from a P-channel MOSFET to an LDO voltage regulator (flipped the logic). Also corrected the image URL in the README.